### PR TITLE
Python 2.7 support

### DIFF
--- a/pycmr/queries.py
+++ b/pycmr/queries.py
@@ -2,12 +2,15 @@
 Class contains all queries used on CMR
 """
 
-from urllib.parse import quote
-from abc import ABC
+try:
+    from urllib.parse import quote
+except ImportError:
+    from urllib import pathname2url as quote
+
 from datetime import datetime
 from requests import get
 
-class Query(ABC):
+class Query(object):
     """
     Base class for all queries
     """

--- a/tests/test_granule.py
+++ b/tests/test_granule.py
@@ -1,5 +1,11 @@
 import unittest
-from urllib.parse import quote, unquote
+
+try:
+    from urllib.parse import quote, unquote
+except ImportError:
+    from urllib import pathname2url as quote
+    from urllib import url2pathname as unquote
+
 from datetime import datetime
 from pycmr.queries import GranuleQuery
 


### PR DESCRIPTION
Addresses issue #30 

Removing ABC was a quick way to handle that issue. There is a way to make ABC work in python 2 and 3 simultaneously, but I figure we might as well wait until we actually need it.