### PR TITLE
Add more spatial options

### DIFF
--- a/pycmr/queries.py
+++ b/pycmr/queries.py
@@ -135,6 +135,34 @@ class Query(object):
         self.params['point'] = point
         return self
 
+    def polygon(self, coordinates):
+        """
+        Set's a polygonal area to search over. Must be used in combination with a
+        collection filtering parameter such as short_name or entry_title.
+
+        :param coordinates: list of (lon, lat) tuples
+        :returns: Query instance
+        """
+
+        if not coordinates:
+            return self
+
+        # convert to floats
+        as_floats = []
+        for lon, lat in coordinates:
+            as_floats.extend([float(lon), float(lat)])
+
+        # last point must match first point to complete polygon
+        if as_floats[0] != as_floats[-2] or as_floats[1] != as_floats[-1]:
+            raise ValueError("Coordinates of the last pair must match the first pair.")
+
+        # convert to strings
+        as_strs = [str(val) for val in as_floats]
+
+        self.params["polygon"] = ",".join(as_strs)
+
+        return self
+
     def downloadable(self, downloadable):
         """
         Set the downloadable value for the query.
@@ -198,7 +226,7 @@ class Query(object):
         options_as_string = "&".join(formatted_options)
 
         url = "{}?{}&{}".format(self.base_url, params_as_string, options_as_string)
-
+        print(url)
         response = get(url)
         return response.json()
 

--- a/pycmr/queries.py
+++ b/pycmr/queries.py
@@ -120,19 +120,24 @@ class Query(object):
         self.params['version'] = version
         return self
 
-    def point(self, point=None):
+    def point(self, lon, lat):
         """
-        Set the point of the search we are querying
+        Set the point of the search we are querying.
+
+        :param lon: longitude to search at
+        :param lat: latitude to search at
+        :returns: Query instance
         """
 
-        if not point:
-            return
+        if not lat or not lon:
+            return self
 
-        # CMR does not support any spaces in the point parameter
-        point = point.replace(' ', '')
-        point = self._urlencodestring(point)
+        # coordinates must be a float
+        lon = float(lon)
+        lat = float(lat)
 
-        self.params['point'] = point
+        self.params['point'] = "{},{}".format(lon, lat)
+
         return self
 
     def polygon(self, coordinates):

--- a/pycmr/queries.py
+++ b/pycmr/queries.py
@@ -147,6 +147,10 @@ class Query(object):
         if not coordinates:
             return self
 
+        # polygon requires at least 4 pairs of coordinates
+        if len(coordinates) < 4:
+            raise ValueError("A polygon requires at least 4 pairs of coordinates")
+
         # convert to floats
         as_floats = []
         for lon, lat in coordinates:

--- a/pycmr/queries.py
+++ b/pycmr/queries.py
@@ -187,7 +187,7 @@ class Query(object):
         )
 
         return self
-    
+
     def line(self, coordinates):
         """
         Sets a line of coordinates to search over. Must be used in combination with a

--- a/pycmr/queries.py
+++ b/pycmr/queries.py
@@ -187,6 +187,30 @@ class Query(object):
         )
 
         return self
+    
+    def line(self, coordinates):
+        """
+        Sets a line of coordinates to search over. Must be used in combination with a
+        collection filtering parameter such as short_name or entry_title.
+
+        :param coordinates: a list of (lon, lat) tuples
+        :returns: Query instance
+        """
+
+        if not coordinates:
+            return self
+
+        # make sure they're all floats
+        as_floats = []
+        for lon, lat in coordinates:
+            as_floats.extend([float(lon), float(lat)])
+
+        # cast back to string for join
+        as_strs = [str(val) for val in as_floats]
+
+        self.params["line"] = ",".join(as_strs)
+
+        return self
 
     def downloadable(self, downloadable):
         """

--- a/pycmr/queries.py
+++ b/pycmr/queries.py
@@ -149,7 +149,7 @@ class Query(object):
 
         # polygon requires at least 4 pairs of coordinates
         if len(coordinates) < 4:
-            raise ValueError("A polygon requires at least 4 pairs of coordinates")
+            raise ValueError("A polygon requires at least 4 pairs of coordinates.")
 
         # convert to floats
         as_floats = []
@@ -199,6 +199,10 @@ class Query(object):
 
         if not coordinates:
             return self
+
+        # need at least 2 pairs of coordinates
+        if len(coordinates) < 2:
+            raise ValueError("A line requires at least 2 pairs of coordinates.")
 
         # make sure they're all floats
         as_floats = []

--- a/pycmr/queries.py
+++ b/pycmr/queries.py
@@ -137,7 +137,7 @@ class Query(object):
 
     def polygon(self, coordinates):
         """
-        Set's a polygonal area to search over. Must be used in combination with a
+        Sets a polygonal area to search over. Must be used in combination with a
         collection filtering parameter such as short_name or entry_title.
 
         :param coordinates: list of (lon, lat) tuples
@@ -164,6 +164,27 @@ class Query(object):
         as_strs = [str(val) for val in as_floats]
 
         self.params["polygon"] = ",".join(as_strs)
+
+        return self
+
+    def bounding_box(self, lower_left_lon, lower_left_lat, upper_right_lon, upper_right_lat):
+        """
+        Sets a rectangular bounding box to search over. Must be used in combination with
+        a collection filtering parameter such as short_name or entry_title.
+
+        :param lower_left_lon: lower left longitude of the box
+        :param lower_left_lat: lower left latitude of the box
+        :param upper_right_lon: upper right longitude of the box
+        :param upper_right_lat: upper right latitude of the box
+        :returns: Query instance
+        """
+
+        self.params["bounding_box"] = "{},{},{},{}".format(
+            float(lower_left_lon),
+            float(lower_left_lat),
+            float(upper_right_lon),
+            float(upper_right_lat)
+        )
 
         return self
 

--- a/tests/test_granule.py
+++ b/tests/test_granule.py
@@ -199,9 +199,8 @@ class TestGranuleClass(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             query.polygon([1, 2, 3])
-            query.polygon([("hey", 1)])
+            query.polygon([("invalid", 1)])
             query.polygon([(1, 1), (2, 1), (1, 1)])
-
 
     def test_polygon_set(self):
         query = GranuleQuery()
@@ -211,3 +210,15 @@ class TestGranuleClass(unittest.TestCase):
 
         query.polygon([("1", 1.1), (2, 1), (2, 2), (1, 1.1)])
         self.assertEqual(query.params["polygon"], "1.0,1.1,2.0,1.0,2.0,2.0,1.0,1.1")
+
+    def test_bounding_box_invalid_set(self):
+        query = GranuleQuery()
+
+        with self.assertRaises(ValueError):
+            query.bounding_box(1, 2, 3, "invalid")
+
+    def test_bounding_box_set(self):
+        query = GranuleQuery()
+
+        query.bounding_box(1, 2, 3, 4)
+        self.assertEqual(query.params["bounding_box"], "1.0,2.0,3.0,4.0")

--- a/tests/test_granule.py
+++ b/tests/test_granule.py
@@ -222,3 +222,18 @@ class TestGranuleClass(unittest.TestCase):
 
         query.bounding_box(1, 2, 3, 4)
         self.assertEqual(query.params["bounding_box"], "1.0,2.0,3.0,4.0")
+
+    def test_line_invalid_set(self):
+        query = GranuleQuery()
+
+        with self.assertRaises(ValueError):
+            query.line("invalid")
+
+    def test_line_set(self):
+        query = GranuleQuery()
+
+        query.line([(1, 1), (2, 2)])
+        self.assertEqual(query.params["line"], "1.0,1.0,2.0,2.0")
+
+        query.line([("1", 1.1), (2, 2)])
+        self.assertEqual(query.params["line"], "1.0,1.1,2.0,2.0")

--- a/tests/test_granule.py
+++ b/tests/test_granule.py
@@ -1,11 +1,5 @@
 import unittest
 
-try:
-    from urllib.parse import quote, unquote
-except ImportError:
-    from urllib import pathname2url as quote
-    from urllib import url2pathname as unquote
-
 from datetime import datetime
 from pycmr.queries import GranuleQuery
 
@@ -17,10 +11,7 @@ class TestGranuleClass(unittest.TestCase):
     version_val = "006"
     version = "version"
 
-    point_val = "44.6,-63.6"
     point = "point"
-    point_space_val = '44.6,                                         -63.6'
-
     online_only = "online_only"
     downloadable = "downloadable"
     entry_id = "entry_title"
@@ -41,24 +32,20 @@ class TestGranuleClass(unittest.TestCase):
         self.assertIn(self.version, query.params)
         self.assertEqual(query.params[self.version], self.version_val)
 
-    def test_point(self):
+    def test_point_set(self):
         query = GranuleQuery()
-        query.point(self.point_val)
+
+        query.point(10, 15.1)
 
         self.assertIn(self.point, query.params)
-        self.assertEqual(unquote(query.params[self.point]), unquote(self.point_val))
+        self.assertEqual(query.params[self.point], "10.0,15.1")
 
-    def test_point_encoding(self):
+    def test_point_invalid_set(self):
         query = GranuleQuery()
-        query.point(self.point_val)
 
-        self.assertEqual(query.params[self.point], quote(self.point_val))
-
-    def test_point_spaces(self):
-        query = GranuleQuery()
-        query.point(self.point_space_val)
-
-        self.assertEqual(query.params[self.point], quote(self.point_val))
+        with self.assertRaises(ValueError):
+            query.point("invalid", 15.1)
+            query.point(10, None)
 
     def test_temporal_invalid_strings(self):
         query = GranuleQuery()
@@ -242,7 +229,7 @@ class TestGranuleClass(unittest.TestCase):
     def test_invalid_spatial_state(self):
         query = GranuleQuery()
 
-        query.point("1, 2")
+        query.point(1, 2)
         self.assertFalse(query._valid_state())
 
         query.polygon([(1, 1), (2, 1), (2, 2), (1, 1)])
@@ -257,5 +244,5 @@ class TestGranuleClass(unittest.TestCase):
     def test_valid_spatial_state(self):
         query = GranuleQuery()
 
-        query.point("1, 2").short_name("test")
+        query.point(1, 2).short_name("test")
         self.assertTrue(query._valid_state())

--- a/tests/test_granule.py
+++ b/tests/test_granule.py
@@ -228,6 +228,7 @@ class TestGranuleClass(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             query.line("invalid")
+            query.line([(1, 1)])
 
     def test_line_set(self):
         query = GranuleQuery()

--- a/tests/test_granule.py
+++ b/tests/test_granule.py
@@ -238,3 +238,24 @@ class TestGranuleClass(unittest.TestCase):
 
         query.line([("1", 1.1), (2, 2)])
         self.assertEqual(query.params["line"], "1.0,1.1,2.0,2.0")
+
+    def test_invalid_spatial_state(self):
+        query = GranuleQuery()
+
+        query.point("1, 2")
+        self.assertFalse(query._valid_state())
+
+        query.polygon([(1, 1), (2, 1), (2, 2), (1, 1)])
+        self.assertFalse(query._valid_state())
+
+        query.bounding_box(1, 1, 2, 2)
+        self.assertFalse(query._valid_state())
+
+        query.line([(1, 1), (2, 2)])
+        self.assertFalse(query._valid_state())
+
+    def test_valid_spatial_state(self):
+        query = GranuleQuery()
+
+        query.point("1, 2").short_name("test")
+        self.assertTrue(query._valid_state())

--- a/tests/test_granule.py
+++ b/tests/test_granule.py
@@ -197,13 +197,17 @@ class TestGranuleClass(unittest.TestCase):
     def test_polygon_invalid_set(self):
         query = GranuleQuery()
 
-        with self.assertRaises(TypeError):
+        with self.assertRaises(ValueError):
             query.polygon([1, 2, 3])
             query.polygon([("hey", 1)])
             query.polygon([(1, 1), (2, 1), (1, 1)])
 
+
     def test_polygon_set(self):
         query = GranuleQuery()
-        query.polygon([(1, 1), (2, 1), (2, 2), (1, 1)])
 
+        query.polygon([(1, 1), (2, 1), (2, 2), (1, 1)])
         self.assertEqual(query.params["polygon"], "1.0,1.0,2.0,1.0,2.0,2.0,1.0,1.0")
+
+        query.polygon([("1", 1.1), (2, 1), (2, 2), (1, 1.1)])
+        self.assertEqual(query.params["polygon"], "1.0,1.1,2.0,1.0,2.0,2.0,1.0,1.1")

--- a/tests/test_granule.py
+++ b/tests/test_granule.py
@@ -193,3 +193,17 @@ class TestGranuleClass(unittest.TestCase):
         with self.assertRaises(TypeError):
             query.day_night_flag(True)
         self.assertNotIn(self.day_night_flag, query.params)
+
+    def test_polygon_invalid_set(self):
+        query = GranuleQuery()
+
+        with self.assertRaises(TypeError):
+            query.polygon([1, 2, 3])
+            query.polygon([("hey", 1)])
+            query.polygon([(1, 1), (2, 1), (1, 1)])
+
+    def test_polygon_set(self):
+        query = GranuleQuery()
+        query.polygon([(1, 1), (2, 1), (2, 2), (1, 1)])
+
+        self.assertEqual(query.params["polygon"], "1.0,1.0,2.0,1.0,2.0,2.0,1.0,1.0")


### PR DESCRIPTION
This pull addresses two things:
1. knocks out the remaining parameters in issue #7 
2. modified the point() method to use lat/lon parameters instead of a string. After using it a few times, I felt this was a more natural and expected way to use the function.