### PR TITLE
Implemented a basic way to throw any error that occurs

### DIFF
--- a/pycmr/queries.py
+++ b/pycmr/queries.py
@@ -8,7 +8,7 @@ except ImportError:
     from urllib import pathname2url as quote
 
 from datetime import datetime
-from requests import get
+from requests import get, exceptions
 
 class Query(object):
     """
@@ -289,8 +289,13 @@ class Query(object):
         options_as_string = "&".join(formatted_options)
 
         url = "{}?{}&{}".format(self.base_url, params_as_string, options_as_string)
-        print(url)
         response = get(url)
+
+        try:
+            response.raise_for_status()
+        except exceptions.HTTPError as ex:
+            raise RuntimeError(ex.response.text)
+
         return response.json()
 
     def _valid_state(self):


### PR DESCRIPTION
Very basic error throwing for query():

```
Python 3.5.2 (default, Nov 17 2016, 17:05:23) 
[GCC 5.4.0 20160609] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from pycmr import queries
>>> query = queries.GranuleQuery()
>>> query.short_name("MOD09GA").point(44444,4444).query()
https://cmr.earthdata.nasa.gov/search/granules.json?point=44444.0,4444.0&short_name=MOD09GA&
Traceback (most recent call last):
  File "/home/misnor/Documents/Workspace/pyCMR/pycmr/queries.py", line 297, in query
    response.raise_for_status()
  File "/usr/local/lib/python3.5/dist-packages/requests/models.py", line 893, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 400 Client Error: Bad Request for url: https://cmr.earthdata.nasa.gov/search/granules.json?point=44444.0,4444.0&short_name=MOD09GA&

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/misnor/Documents/Workspace/pyCMR/pycmr/queries.py", line 299, in query
    raise RuntimeError(ex.response.text)
RuntimeError: {"errors":["Point longitude [44444] must be within -180.0 and 180.0","Point latitude [4444] must be within -90 and 90.0"]}

```

Just allowing the 400 to raise gives no valuable info to the developer, thus the RunTimeException with response.text.