### PR TITLE
Feature/pagination

### DIFF
--- a/cmr/queries.py
+++ b/cmr/queries.py
@@ -49,7 +49,7 @@ class Query(object):
 
             results = results + latest
             page += 1
-        return results[0:limit]
+        return results
 
     def _urlencodestring(self, value):
         """

--- a/tests/test_granule.py
+++ b/tests/test_granule.py
@@ -320,3 +320,11 @@ class TestGranuleClass(unittest.TestCase):
 
         query.point(1, 2).short_name("test")
         self.assertTrue(query._valid_state())
+
+    def _test_query(self):
+        """ Test real query """
+        query = GranuleQuery()
+        query.short_name('MCD43A4').version('005')
+        query.temporal(datetime(2016, 1, 1), datetime(2016, 1, 1))
+        results = query.query(limit=10)
+        self.assertEqual(len(results), 10)


### PR DESCRIPTION
Partially implements issue #9 

Does not currently support offset or sort_key.  

The .query member function now has an optional limit keyword, and will retrieve up to that number, or the maximum available, regardless of # of requests (pages) that need to be made.

I also added a real query test, as I was using it when adding the pagination, but it's currently disabled. Should probably be an integration test, probably in a separate test file as in #25 