### PR TITLE
Fix/pagination

### DIFF
--- a/cmr/queries.py
+++ b/cmr/queries.py
@@ -37,12 +37,6 @@ class Query(object):
         results = []
         page = 1
         while len(results) < limit:
-            
-            # cut page_size down if this is the last iteration and we need less than the
-            # full page_size of results to reach the limit
-            #if limit - len(results) < page_size:
-            #    page_size = limit - len(results)
-
             response = get(url, params={'page_size': page_size, 'page_num': page}, verify=False)
 
             try:

--- a/cmr/queries.py
+++ b/cmr/queries.py
@@ -40,8 +40,8 @@ class Query(object):
             
             # cut page_size down if this is the last iteration and we need less than the
             # full page_size of results to reach the limit
-            if limit - len(results) < page_size:
-                page_size = limit - len(results)
+            #if limit - len(results) < page_size:
+            #    page_size = limit - len(results)
 
             response = get(url, params={'page_size': page_size, 'page_num': page}, verify=False)
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="python-cmr",
-    version="0.1b",
+    version="0.1b2",
     license="MIT",
     url="https://github.com/jddeal/python-cmr",
     description="Python wrapper to the NASA Common Metadata Repository API.",

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="python-cmr",
-    version="0.1",
+    version="0.1b",
     license="MIT",
     url="https://github.com/jddeal/python-cmr",
     description="Python wrapper to the NASA Common Metadata Repository API.",


### PR DESCRIPTION
fixes pagination.

The problem was that by changing the page size for the last page (cutting it down to be equal to the number of results left), actually changes the total number of pages, so you end up not getting the last results, but rather results from earlier, causing duplicates.

Leaving the page size alone doesn't hurt anything for the last page, since CMR will just return the last ones left, be it one or 2000.