### PR TITLE
Prepare for pypi

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,2 @@
 include LICENSE
-include README.md
+include README.rst

--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ Python CMR is an easy to use wrapper to the NASA EOSDIS
 querying the API intuitive and less error-prone by providing methods that will preemptively check
 for invalid input and handle the URL encoding the CMR API expects.
 
-Getting access to NASA's earth science data is as simple as this:
+Getting access to NASA's earth science metadata is as simple as this:
 
 ::
 
@@ -31,6 +31,25 @@ Getting access to NASA's earth science data is as simple as this:
     SC:AST_L1T.003:2150165250
     SC:AST_L1T.003:2150261715
     SC:AST_L1T.003:2150315169
+
+
+Installation
+============
+
+To install from pypi:
+
+::
+
+    $ pip install python-cmr
+
+
+To install from github, perhaps to try out the dev branch:
+
+::
+
+    $ git clone https://github.com/jddeal/python-cmr
+    $ cd python-cmr
+    $ pip install .
 
 
 Examples
@@ -104,16 +123,3 @@ To inspect and retreive results from the API, the following methods are availabl
 
     # retrieve all the granules possible for the query
     >>> granules = api.get_all()  # this is a shortcut for api.get(api.hits())
-
-
-Installation
-============
-
-Simply clone and install via pip.
-
-::
-
-    $ git clone https://github.com/jddeal/python-cmr
-    $ cd python-cmr
-    $ pip install .
-

--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@ for invalid input and handle the URL encoding the CMR API expects.
 
 Getting access to NASA's earth science data is as simple as this:
 
-.. code-block:: python
+::
 
     >>> from cmr import GranuleQuery
 
@@ -20,7 +20,7 @@ Getting access to NASA's earth science data is as simple as this:
     >>> granules = api.short_name("AST_L1T").point(-112.73, 42.5).get(10)
 
     >>> for granule in granules:
-    >>>   print(granule["entry_title"])
+    >>>   print(granule["title"])
     SC:AST_L1T.003:2149105822
     SC:AST_L1T.003:2149105820
     SC:AST_L1T.003:2149155037
@@ -39,7 +39,7 @@ Examples
 The CMR API provides many parameters, but not all of them are covered by this version of
 the wrapper. The following shows the possible parameters supported by the wrapper:
 
-.. code-block:: python
+::
 
     >>> from cmr import GranuleQuery
 
@@ -91,7 +91,7 @@ the wrapper. The following shows the possible parameters supported by the wrappe
 
 To inspect and retreive results from the API, the following methods are available:
 
-.. code-block:: python
+::
 
     # inspect the number of results the query will return without downloading the results
     >>> print(api.hits())
@@ -111,7 +111,7 @@ Installation
 
 Simply clone and install via pip.
 
-.. code-block:: bash
+::
 
     $ git clone https://github.com/jddeal/python-cmr
     $ cd python-cmr

--- a/cmr/queries.py
+++ b/cmr/queries.py
@@ -43,7 +43,7 @@ class Query(object):
             if limit - len(results) < page_size:
                 page_size = limit - len(results)
 
-            response = get(url, params={'page_size': page_size, 'page_num': page}, verify=False)
+            response = get(url, params={'page_size': page_size, 'page_num': page})
 
             try:
                 response.raise_for_status()
@@ -69,7 +69,7 @@ class Query(object):
 
         url = self._build_url()
 
-        response = get(url, params={'page_size': 0}, verify=False)
+        response = get(url, params={'page_size': 0})
 
         try:
             response.raise_for_status()

--- a/setup.py
+++ b/setup.py
@@ -2,14 +2,15 @@ from setuptools import setup
 
 setup(
     name="python-cmr",
-    version="0.1",
+    version="0.1b1",
     license="MIT",
     url="https://github.com/jddeal/python-cmr",
-    description="Python wrapper to the NASA Common Metadata Repository API.",
+    description="Python wrapper to the NASA Common Metadata Repository (CMR) API.",
+    long_description=open("README.rst").read(),
     author="Justin Deal, Matt Isnor",
     author_email="deal.justin@gmail.com, isnor.matt@gmail.com",
     packages=["cmr"],
     install_requires=[
-        "requests==2.12.4",
+        "requests",
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="python-cmr",
-    version="0.1b1",
+    version="0.1b2",
     license="MIT",
     url="https://github.com/jddeal/python-cmr",
     description="Python wrapper to the NASA Common Metadata Repository (CMR) API.",


### PR DESCRIPTION
Addresses #40.

The package has been [uploaded to PyPI](https://pypi.python.org/pypi/python-cmr) at the current version. The only code change was a quick removal of some `verify=False` parameters in the requests calls that probably should have been eliminated awhile ago.