### PR TITLE
Fix/issue58

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -77,15 +77,15 @@ The following methods are available to both collecton and granule queries:
     >>> api.bounding_box(-112.70, 42.5, -110, 44.5)
 
     # search for granules in a polygon
-    >>> api.polygon((-100, 40), (-90, 40), (-95, 38), (-100, 40))
+    >>> api.polygon([(-100, 40), (-90, 40), (-95, 38), (-100, 40)])
 
     # search for granules in a line
-    >>> api.line((-100, 40), (-90, 40), (-95, 38))
+    >>> api.line([(-100, 40), (-90, 40), (-95, 38)])
 
     # search for granules in an open or closed date range
     >>> api.temporal("2016-10-10T01:02:00Z", "2016-10-12T00:00:30Z")
     >>> api.temporal("2016-10-10T01:02:00Z", None)
-    >>> api.temporal(datetime("2016-10-10T01:02:00Z"), datetime.now())
+    >>> api.temporal(datetime(2016, 10, 10, 1, 2, 0), datetime.now())
 
     # only include granules available for download
     >>> api.downloadable()

--- a/cmr/queries.py
+++ b/cmr/queries.py
@@ -402,6 +402,8 @@ class Query(object):
             if isinstance(val, list):
                 for list_val in val:
                     formatted_params.append("{}[]={}".format(key, list_val))
+            elif isinstance(val, bool):
+                formatted_params.append("{}={}".format(key, str(val).lower()))
             else:
                 formatted_params.append("{}={}".format(key, val))
 

--- a/cmr/queries.py
+++ b/cmr/queries.py
@@ -283,6 +283,12 @@ class Query(object):
 
         if not coordinates:
             return self
+    
+        # make sure we were passed something iterable
+        try:
+            iter(coordinates)
+        except TypeError:
+            raise ValueError("A line must be an iterable of coordinate tuples. Ex: [(90,90), (91, 90), ...]")
 
         # polygon requires at least 4 pairs of coordinates
         if len(coordinates) < 4:
@@ -336,6 +342,12 @@ class Query(object):
 
         if not coordinates:
             return self
+        
+        # make sure we were passed something iterable
+        try:
+            iter(coordinates)
+        except TypeError:
+            raise ValueError("A line must be an iterable of coordinate tuples. Ex: [(90,90), (91, 90), ...]")
 
         # need at least 2 pairs of coordinates
         if len(coordinates) < 2:

--- a/cmr/queries.py
+++ b/cmr/queries.py
@@ -149,7 +149,7 @@ class Query(object):
         # if we got here, we didn't find a matching format
         raise ValueError("Unsupported format '{}'".format(output_format))
 
-    def online_only(self, online_only):
+    def online_only(self, online_only=True):
         """
         Only match granules that are listed online and not available for download.
         The opposite of this method is downloadable().
@@ -160,6 +160,10 @@ class Query(object):
 
         if not isinstance(online_only, bool):
             raise TypeError("Online_only must be of type bool")
+
+        # remove the inverse flag so CMR doesn't crash
+        if "downloadable" in self.params:
+            del self.params["downloadable"]
 
         self.params['online_only'] = online_only
 
@@ -365,7 +369,7 @@ class Query(object):
 
         return self
 
-    def downloadable(self, downloadable):
+    def downloadable(self, downloadable=True):
         """
         Only match granules that are available for download. The opposite of this
         method is online_only().
@@ -373,9 +377,14 @@ class Query(object):
         :param downloadable: True to require granules be downloadable
         :returns: Query instance
         """
+
         if not isinstance(downloadable, bool):
             raise TypeError("Downloadable must be of type bool")
-
+        
+        # remove the inverse flag so CMR doesn't crash
+        if "online_only" in self.params:
+            del self.params["online_only"]
+        
         self.params['downloadable'] = downloadable
 
         return self

--- a/cmr/queries.py
+++ b/cmr/queries.py
@@ -60,12 +60,12 @@ class Query(object):
             if self._format == "json":
                 latest = response.json()['feed']['entry']
             else:
-                latest = response.text
+                latest = [response.text]
 
             if len(latest) == 0:
                 break
 
-            results.append(latest)
+            results.extend(latest)
             page += 1
 
         return results

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="python-cmr",
-    version="0.3",
+    version="0.3.1",
     license="MIT",
     url="https://github.com/jddeal/python-cmr",
     description="Python wrapper to the NASA Common Metadata Repository (CMR) API.",

--- a/tests/test_granule.py
+++ b/tests/test_granule.py
@@ -381,3 +381,11 @@ class TestGranuleClass(unittest.TestCase):
             query.format("invalid")
             query.format("jsonn")
             query.format("iso19116")
+
+    def test_lowercase_bool_url(self):
+        query = GranuleQuery()
+        query.parameters(short_name="AST_LIT", online_only=True, downloadable=False)
+
+        url = query._build_url()
+        self.assertNotIn("True", url)
+        self.assertNotIn("False", url)

--- a/tests/test_granule.py
+++ b/tests/test_granule.py
@@ -290,6 +290,7 @@ class TestGranuleClass(unittest.TestCase):
         with self.assertRaises(ValueError):
             query.line("invalid")
             query.line([(1, 1)])
+            query.line(1)
 
     def test_line_set(self):
         query = GranuleQuery()

--- a/tests/test_granule.py
+++ b/tests/test_granule.py
@@ -103,30 +103,59 @@ class TestGranuleClass(unittest.TestCase):
 
     def test_online_only_set(self):
         query = GranuleQuery()
-        query.online_only(True)
 
+        # default to True
+        query.online_only()
         self.assertIn(self.online_only, query.params)
         self.assertEqual(query.params[self.online_only], True)
+
+        # explicitly set to False
+        query.online_only(False)
+
+        self.assertIn(self.online_only, query.params)
+        self.assertEqual(query.params[self.online_only], False)
 
     def test_online_only_invalid(self):
         query = GranuleQuery()
 
         with self.assertRaises(TypeError):
             query.online_only("Invalid Type")
+
         self.assertNotIn(self.online_only, query.params)
 
     def test_downloadable_set(self):
         query = GranuleQuery()
-        query.downloadable(True)
+
+        # default to True
+        query.downloadable()
 
         self.assertIn(self.downloadable, query.params)
         self.assertEqual(query.params[self.downloadable], True)
+
+        # explicitly set to False
+        query.downloadable(False)
+
+        self.assertIn(self.downloadable, query.params)
+        self.assertEqual(query.params[self.downloadable], False)
 
     def test_downloadable_invalid(self):
         query = GranuleQuery()
 
         with self.assertRaises(TypeError):
             query.downloadable("Invalid Type")
+        self.assertNotIn(self.downloadable, query.params)
+    
+    def test_flags_invalidate_the_other(self):
+        query = GranuleQuery()
+
+        # if downloadable is set, online_only should be unset
+        query.downloadable()
+        self.assertIn(self.downloadable, query.params)
+        self.assertNotIn(self.online_only, query.params)
+
+        # if online_only is set, downloadable should be unset
+        query.online_only()
+        self.assertIn(self.online_only, query.params)
         self.assertNotIn(self.downloadable, query.params)
 
     def test_entry_title_set(self):


### PR DESCRIPTION
Fixes the issues brought up in #58. Also added in iterable argument checks and a check for bad flag state that CMR can't handle.

Dunno why github thinks the cmr/queries.py change of append -> extend is showing up in the PR. That was fixed in the last release and looking at the latest in dev shows it's there.