### PR TITLE
remove trailing & which breaks in CMR of Feb-March

### DIFF
--- a/cmr/queries.py
+++ b/cmr/queries.py
@@ -449,13 +449,14 @@ class Query(object):
                 ))
 
         options_as_string = "&".join(formatted_options)
-
-        return "{}.{}?{}&{}".format(
+        res = "{}.{}?{}&{}".format(
             self._base_url,
             self._format,
             params_as_string,
             options_as_string
         )
+        res = res.rstrip('&')
+        return res
 
     def _valid_state(self):
         """


### PR DESCRIPTION
The latest version of python-cmr no longer works with CMR. Sometime around the end of Feb or early March there must have been a change in CMR to make it more strict in it's parsing. 

python-cmr was using a URL with two ampersands in a row   The built URL returned a trailing &, and then page_size and page_num were appended on to that by `requests.get` to create two & in a row.

This causes a response from CMR:
```
Excessive query rate. Please contact support@earthdata.nasa.gov.
```