### PR TITLE
add tools and services query class

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,7 @@ Getting access to NASA's earth science metadata is as simple as this:
 
 ::
 
-    >>> from cmr import CollectionQuery, GranuleQuery
+    >>> from cmr import CollectionQuery, GranuleQuery, ToolQuery, ServiceQuery
     
     >>> api = CollectionQuery()
     >>> collections = api.archive_center("LP DAAC").keyword("AST_L1*").get(5)
@@ -102,6 +102,9 @@ The following methods are available to both collecton and granule queries:
     >>> api.concept_id("C1299783579-LPDAAC_ECS")
     >>> api.concept_id(["G1327299284-LPDAAC_ECS", "G1326330014-LPDAAC_ECS"])
 
+    # search by provider
+    >>> api.provider('POCLOUD')
+
 
 Granule searches support these methods (in addition to the shared methods above):
 
@@ -121,7 +124,7 @@ Granule searches support these methods (in addition to the shared methods above)
     # filter by specific instrument or platform
     >>> api.instrument("MODIS")
     >>> api.platform("Terra")
-    
+
 
 Collection searches support these methods (in addition to the shared methods above):
 
@@ -133,6 +136,37 @@ Collection searches support these methods (in addition to the shared methods abo
     # case insensitive, wildcard enabled text search through most collection fields
     >>> api.keyword("M*D09")
 
+    # search by native_id
+    >>> api.native_id('native_id')
+
+    # filter by tool concept id
+    >>> api.tool_concept_id('TL2092786348-POCLOUD')
+
+    # filter by service concept id
+    >>> api.service_concept_id('S1962070864-POCLOUD')
+
+Service searches support the following methods
+
+::
+    # Search via provider
+    >>> api = ServiceQuery()
+    >>> api.provider('POCLOUD')
+    # Search via native_id
+    >>> api.native_id('POCLOUD_podaac_l2_cloud_subsetter')
+    # Search via name
+    >>> api.name('PODAAC L2 Cloud Subsetter')
+
+
+Tool searches support the following methods
+
+::
+    # Search via provider
+    >>> api = ToolQuery()
+    >>> api.provider('POCLOUD')
+    # Search via native_id
+    >>> api.native_id('POCLOUD_hitide')
+    # Search via name
+    >>> api.name('hitide')
 
 As an alternative to chaining methods together to set the parameters of your query, a
 method exists to allow you to pass your parameters as keyword arguments:

--- a/README.rst
+++ b/README.rst
@@ -148,6 +148,7 @@ Collection searches support these methods (in addition to the shared methods abo
 Service searches support the following methods
 
 ::
+
     # Search via provider
     >>> api = ServiceQuery()
     >>> api.provider('POCLOUD')
@@ -160,6 +161,7 @@ Service searches support the following methods
 Tool searches support the following methods
 
 ::
+
     # Search via provider
     >>> api = ToolQuery()
     >>> api.provider('POCLOUD')

--- a/cmr/queries.py
+++ b/cmr/queries.py
@@ -724,7 +724,7 @@ class CollectionQuery(GranuleCollectionBaseQuery):
         # verify we provided with tool concept IDs
         for ID in IDs:
             if ID.strip()[0] != "T":
-                raise ValueError("Only tool concept ID's can be provided (begin with 'C'): {}".format(ID))
+                raise ValueError("Only tool concept ID's can be provided (begin with 'T'): {}".format(ID))
         
         self.params["tool_concept_id"] = IDs
 
@@ -746,7 +746,7 @@ class CollectionQuery(GranuleCollectionBaseQuery):
         # verify we provided with service concept IDs
         for ID in IDs:
             if ID.strip()[0] != "S":
-                raise ValueError("Only service concept ID's can be provided (begin with 'C'): {}".format(ID))
+                raise ValueError("Only service concept ID's can be provided (begin with 'S'): {}".format(ID))
         
         self.params["service_concept_id"] = IDs
 

--- a/cmr/queries.py
+++ b/cmr/queries.py
@@ -243,21 +243,6 @@ class Query(object):
         self.params['provider'] = provider
         return self
 
-    def native_id(self, native_ids):
-        """
-        Filter by native id.
-
-        :param native_id: native id for tool
-        :returns: Query instance
-        """
-
-        if isinstance(native_ids, str):
-            native_ids = [native_ids]
-        
-        self.params["native_id"] = native_ids
-
-        return self
-
     def _valid_state(self):
         """
         Determines if the Query is in a valid state based on the parameters and options
@@ -708,6 +693,21 @@ class CollectionQuery(GranuleCollectionBaseQuery):
 
         return self
 
+    def native_id(self, native_ids):
+        """
+        Filter by native id.
+
+        :param native_id: native id for collection
+        :returns: Query instance
+        """
+
+        if isinstance(native_ids, str):
+            native_ids = [native_ids]
+        
+        self.params["native_id"] = native_ids
+
+        return self
+
     def tool_concept_id(self, IDs):
         """
         Filter collections associated with tool concept ID (ex: TL2092786348-POCLOUD)
@@ -794,6 +794,21 @@ class ToolServiceBaseQuery(Query):
             page += 1
 
         return results
+
+    def native_id(self, native_ids):
+        """
+        Filter by native id.
+
+        :param native_id: native id for tool or service
+        :returns: Query instance
+        """
+
+        if isinstance(native_ids, str):
+            native_ids = [native_ids]
+        
+        self.params["native_id"] = native_ids
+
+        return self
 
     def name(self, name):
         """

--- a/cmr/queries.py
+++ b/cmr/queries.py
@@ -34,6 +34,7 @@ class Query(object):
         self.options = {}
         self._route = route
         self.mode(mode)
+        self.concept_id_chars = []
 
     def get(self, limit=2000):
         """
@@ -148,6 +149,142 @@ class Query(object):
 
         # if we got here, we didn't find a matching format
         raise ValueError("Unsupported format '{}'".format(output_format))
+
+    def _build_url(self):
+        """
+        Builds the URL that will be used to query CMR.
+
+        :returns: the url as a string
+        """
+
+        # last chance validation for parameters
+        if not self._valid_state():
+            raise RuntimeError(("Spatial parameters must be accompanied by a collection "
+                                "filter (ex: short_name or entry_title)."))
+
+        # encode params
+        formatted_params = []
+        for key, val in self.params.items():
+
+            # list params require slightly different formatting
+            if isinstance(val, list):
+                for list_val in val:
+                    formatted_params.append("{}[]={}".format(key, list_val))
+            elif isinstance(val, bool):
+                formatted_params.append("{}={}".format(key, str(val).lower()))
+            else:
+                formatted_params.append("{}={}".format(key, val))
+
+        params_as_string = "&".join(formatted_params)
+
+        # encode options
+        formatted_options = []
+        for param_key in self.options:
+            for option_key, val in self.options[param_key].items():
+
+                # all CMR options must be booleans
+                if not isinstance(val, bool):
+                    raise ValueError("parameter '{}' with option '{}' must be a boolean".format(
+                        param_key,
+                        option_key
+                    ))
+
+                formatted_options.append("options[{}][{}]={}".format(
+                    param_key,
+                    option_key,
+                    val
+                ))
+
+        options_as_string = "&".join(formatted_options)
+        res = "{}.{}?{}&{}".format(
+            self._base_url,
+            self._format,
+            params_as_string,
+            options_as_string
+        )
+        res = res.rstrip('&')
+        return res
+
+    def concept_id(self, IDs):
+        """
+        Filter by concept ID (ex: C1299783579-LPDAAC_ECS or G1327299284-LPDAAC_ECS, T12345678-LPDAAC_ECS, S12345678-LPDAAC_ECS)
+
+        Collections, granules, tools, services are uniquely identified with this ID. 
+        If providing a collection's concept ID here, it will filter by granules associated with that collection. 
+        If providing a granule's concept ID here, it will uniquely identify those granules.
+        If providing a tool's concept ID here, it will uniquely identify those tools.
+        If providing a service's concept ID here, it will uniquely identify those services.
+
+        :param IDs: concept ID(s) to search by. Can be provided as a string or list of strings.
+        :returns: Query instance
+        """
+
+        if isinstance(IDs, str):
+            IDs = [IDs]
+        
+        # verify we weren't provided any granule concept IDs
+        for ID in IDs:
+            if ID.strip()[0] not in self.concept_id_chars:
+                raise ValueError("Only concept ids that begin with '{}' can be provided: {}".format(self.concept_id_chars, ID))
+
+        self.params["concept_id"] = IDs
+
+    def provider(self, provider):
+        """
+        Filter by provider.
+
+        :param provider: provider of tool.
+        :returns: Query instance
+        """
+
+        if not provider:
+            return self
+
+        self.params['provider'] = provider
+        return self
+
+    def native_id(self, native_ids):
+        """
+        Filter by native id.
+
+        :param native_id: native id for tool
+        :returns: Query instance
+        """
+
+        if isinstance(native_ids, str):
+            native_ids = [native_ids]
+        
+        self.params["native_id"] = native_ids
+
+        return self
+
+    def _valid_state(self):
+        """
+        Determines if the Query is in a valid state based on the parameters and options
+        that have been set. This should be implemented by the subclasses.
+
+        :returns: True if the state is valid, otherwise False
+        """
+
+        raise NotImplementedError()
+
+    def mode(self, mode=CMR_OPS):
+        """
+        Sets the mode of the api target to the given URL
+        CMR_OPS, CMR_UAT, CMR_SIT are provided as class variables
+
+        :param mode: Mode to set the query to target
+        :throws: Will throw if provided None
+        """
+        if mode is None:
+            raise ValueError("Please provide a valid mode (CMR_OPS, CMR_UAT, CMR_SIT)")
+
+        self._base_url = str(mode) + self._route
+
+class GranuleCollectionBaseQuery(Query):
+    """
+    Base class for Granule and Collection CMR queries.
+    """
 
     def online_only(self, online_only=True):
         """
@@ -380,7 +517,7 @@ class Query(object):
 
         if not isinstance(downloadable, bool):
             raise TypeError("Downloadable must be of type bool")
-        
+
         # remove the inverse flag so CMR doesn't crash
         if "online_only" in self.params:
             del self.params["online_only"]
@@ -403,91 +540,15 @@ class Query(object):
 
         return self
 
-    def _build_url(self):
-        """
-        Builds the URL that will be used to query CMR.
 
-        :returns: the url as a string
-        """
-
-        # last chance validation for parameters
-        if not self._valid_state():
-            raise RuntimeError(("Spatial parameters must be accompanied by a collection "
-                                "filter (ex: short_name or entry_title)."))
-
-        # encode params
-        formatted_params = []
-        for key, val in self.params.items():
-
-            # list params require slightly different formatting
-            if isinstance(val, list):
-                for list_val in val:
-                    formatted_params.append("{}[]={}".format(key, list_val))
-            elif isinstance(val, bool):
-                formatted_params.append("{}={}".format(key, str(val).lower()))
-            else:
-                formatted_params.append("{}={}".format(key, val))
-
-        params_as_string = "&".join(formatted_params)
-
-        # encode options
-        formatted_options = []
-        for param_key in self.options:
-            for option_key, val in self.options[param_key].items():
-
-                # all CMR options must be booleans
-                if not isinstance(val, bool):
-                    raise ValueError("parameter '{}' with option '{}' must be a boolean".format(
-                        param_key,
-                        option_key
-                    ))
-
-                formatted_options.append("options[{}][{}]={}".format(
-                    param_key,
-                    option_key,
-                    val
-                ))
-
-        options_as_string = "&".join(formatted_options)
-        res = "{}.{}?{}&{}".format(
-            self._base_url,
-            self._format,
-            params_as_string,
-            options_as_string
-        )
-        res = res.rstrip('&')
-        return res
-
-    def _valid_state(self):
-        """
-        Determines if the Query is in a valid state based on the parameters and options
-        that have been set. This should be implemented by the subclasses.
-
-        :returns: True if the state is valid, otherwise False
-        """
-
-        raise NotImplementedError()
-
-    def mode(self, mode=CMR_OPS):
-        """
-        Sets the mode of the api target to the given URL
-        CMR_OPS, CMR_UAT, CMR_SIT are provided as class variables
-
-        :param mode: Mode to set the query to target
-        :throws: Will throw if provided None
-        """
-        if mode is None:
-            raise ValueError("Please provide a valid mode (CMR_OPS, CMR_UAT, CMR_SIT)")
-
-        self._base_url = str(mode) + self._route
-
-class GranuleQuery(Query):
+class GranuleQuery(GranuleCollectionBaseQuery):
     """
     Class for querying granules from the CMR.
     """
 
     def __init__(self, mode=CMR_OPS):
         Query.__init__(self, "granules", mode)
+        self.concept_id_chars = ['G', 'C']
 
     def orbit_number(self, orbit1, orbit2=None):
         """"
@@ -593,25 +654,6 @@ class GranuleQuery(Query):
         self.params['granule_ur'] = granule_ur
         return self
 
-    def concept_id(self, IDs):
-        """
-        Filter by concept ID (ex: C1299783579-LPDAAC_ECS or G1327299284-LPDAAC_ECS)
-
-        Collections and granules are uniquely identified with this ID. If providing a collection's concept ID
-        here, it will filter by granules associated with that collection. If providing a granule's concept ID
-        here, it will uniquely identify those granules.
-
-        :param IDs: concept ID(s) to search by. Can be provided as a string or list of strings.
-        :returns: Query instance
-        """
-
-        if isinstance(IDs, str):
-            IDs = [IDs]
-        
-        self.params["concept_id"] = IDs
-
-        return self
-
     def _valid_state(self):
 
         # spatial params must be paired with a collection limiting parameter
@@ -626,14 +668,14 @@ class GranuleQuery(Query):
         return True
 
 
-class CollectionQuery(Query):
+class CollectionQuery(GranuleCollectionBaseQuery):
     """
     Class for querying collections from the CMR.
     """
 
     def __init__(self, mode=CMR_OPS):
         Query.__init__(self, "collections", mode)
-
+        self.concept_id_chars = ['C']
         self._valid_formats_regex.extend([
             "dif", "dif10", "opendata", "umm_json", "umm_json_v[0-9]_[0-9]"
         ])
@@ -666,27 +708,134 @@ class CollectionQuery(Query):
 
         return self
 
-    def concept_id(self, IDs):
+    def tool_concept_id(self, IDs):
         """
-        Filter by concept ID (ex: C1299783579-LPDAAC_ECS)
+        Filter collections associated with tool concept ID (ex: TL2092786348-POCLOUD)
 
-        Collections are uniquely identified with this ID.
+        Collections are associated with this tool ID.
 
-        :param IDs: concept ID(s) to search by. Can be provided as a string or list of strings.
+        :param IDs: tool concept ID(s) to search by. Can be provided as a string or list of strings.
+        :returns: Query instance
+        """
+
+        if isinstance(IDs, str):
+            IDs = [IDs]
+
+        # verify we provided with tool concept IDs
+        for ID in IDs:
+            if ID.strip()[0] != "T":
+                raise ValueError("Only tool concept ID's can be provided (begin with 'C'): {}".format(ID))
+        
+        self.params["tool_concept_id"] = IDs
+
+        return self
+
+    def service_concept_id(self, IDs):
+        """
+        Filter collections associated with service ID (ex: S1962070864-POCLOUD)
+
+        Collections are associated with this service ID.
+
+        :param IDs: service concept ID(s) to search by. Can be provided as a string or list of strings.
         :returns: Query instance
         """
 
         if isinstance(IDs, str):
             IDs = [IDs]
         
-        # verify we weren't provided any granule concept IDs
+        # verify we provided with service concept IDs
         for ID in IDs:
-            if ID.strip()[0] != "C":
-                raise ValueError("Only collection concept ID's can be provided (begin with 'C'): {}".format(ID))
+            if ID.strip()[0] != "S":
+                raise ValueError("Only service concept ID's can be provided (begin with 'C'): {}".format(ID))
         
-        self.params["concept_id"] = IDs
+        self.params["service_concept_id"] = IDs
 
         return self
+
+    def _valid_state(self):
+        return True
+
+class ToolServiceBaseQuery(Query):
+    """
+    Base class for Tool and Service CMR queries.
+    """
+
+    def get(self, limit=2000):
+        """
+        Get all results up to some limit, even if spanning multiple pages.
+
+        :limit: The number of results to return
+        :returns: query results as a list
+        """
+
+        page_size = min(limit, 2000)
+        url = self._build_url()
+
+        results = []
+        page = 1
+        while len(results) < limit:
+
+            response = get(url, params={'page_size': page_size, 'page_num': page})
+
+            try:
+                response.raise_for_status()
+            except exceptions.HTTPError as ex:
+                raise RuntimeError(ex.response.text)
+
+            if self._format == "json":
+                latest = response.json()['items']
+            else:
+                latest = [response.text]
+
+            if len(latest) == 0:
+                break
+
+            results.extend(latest)
+            page += 1
+
+        return results
+
+    def name(self, name):
+        """
+        Filter by name.
+
+        :param name: name of service or tool.
+        :returns: Query instance
+        """
+
+        if not name:
+            return self
+
+        self.params['name'] = name
+        return self
+
+class ToolQuery(ToolServiceBaseQuery):
+    """
+    Class for querying tools from the CMR.
+    """
+
+    def __init__(self, mode=CMR_OPS):
+        Query.__init__(self, "tools", mode)
+        self.concept_id_chars = ['T']
+        self._valid_formats_regex.extend([
+            "dif", "dif10", "opendata", "umm_json", "umm_json_v[0-9]_[0-9]"
+        ])
+
+    def _valid_state(self):
+        return True
+
+
+class ServiceQuery(ToolServiceBaseQuery):
+    """
+    Class for querying services from the CMR.
+    """
+
+    def __init__(self, mode=CMR_OPS):
+        Query.__init__(self, "services", mode)
+        self.concept_id_chars = ['S']
+        self._valid_formats_regex.extend([
+            "dif", "dif10", "opendata", "umm_json", "umm_json_v[0-9]_[0-9]"
+        ])
 
     def _valid_state(self):
         return True

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -37,6 +37,33 @@ class TestCollectionClass(unittest.TestCase):
             query.format("jsonn")
             query.format("iso19116")
     
+    def test_tool_concept_id(self):
+        query = CollectionQuery()
+        query.tool_concept_id("T1299783579-LPDAAC_ECS")
+
+        self.assertIn("tool_concept_id", query.params)
+        self.assertEqual(query.params["tool_concept_id"], ["T1299783579-LPDAAC_ECS"])
+
+    def test_invalid_tool_concept_id(self):
+        query = CollectionQuery()
+
+        with self.assertRaises(ValueError):
+            query.tool_concept_id("G1327299284-LPDAAC_ECS")
+
+    def test_service_concept_id(self):
+        query = CollectionQuery()
+ 
+        query.service_concept_id("S1299783579-LPDAAC_ECS")
+
+        self.assertIn("service_concept_id", query.params)
+        self.assertEqual(query.params["service_concept_id"], ["S1299783579-LPDAAC_ECS"])
+
+    def test_invalid_service_concept_id(self):
+        query = CollectionQuery()
+
+        with self.assertRaises(ValueError):
+            query.service_concept_id("G1327299284-LPDAAC_ECS")    
+
     def test_valid_concept_id(self):
         query = CollectionQuery()
 
@@ -54,4 +81,3 @@ class TestCollectionClass(unittest.TestCase):
         
         with self.assertRaises(ValueError):
             query.concept_id(["C1299783579-LPDAAC_ECS", "G1327299284-LPDAAC_ECS"])
-

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1,0 +1,71 @@
+import unittest
+
+from cmr.queries import ServiceQuery
+
+class TestServiceClass(unittest.TestCase):
+
+    def test_name(self):
+        query = ServiceQuery()
+        query.name("name")
+
+        self.assertIn("name", query.params)
+        self.assertEqual(query.params["name"], "name")
+    
+    def test_provider(self):
+        query = ServiceQuery()
+        query.provider("provider")
+
+        self.assertIn("provider", query.params)
+        self.assertEqual(query.params["provider"], "provider")
+
+    def test_native_id(self):
+        query = ServiceQuery()
+        query.native_id("native_id")
+
+        self.assertIn("native_id", query.params)
+        self.assertEqual(query.params["native_id"], ["native_id"])
+
+    def test_native_ids(self):
+        query = ServiceQuery()
+        query.native_id(["native_id1", "native_id2"])
+
+        self.assertIn("native_id", query.params)
+        self.assertEqual(query.params["native_id"], ["native_id1", "native_id2"])
+    
+    def test_valid_formats(self):
+        query = ServiceQuery()
+        formats = [
+            "json", "xml", "echo10", "iso", "iso19115",
+            "csv", "atom", "kml", "native", "dif", "dif10",
+            "opendata", "umm_json", "umm_json_v1_1" "umm_json_v1_9"]
+
+        for _format in formats:
+            query.format(_format)
+            self.assertEqual(query._format, _format)
+    
+    def test_invalid_format(self):
+        query = ServiceQuery()
+
+        with self.assertRaises(ValueError):
+            query.format("invalid")
+            query.format("jsonn")
+            query.format("iso19116")
+    
+    def test_valid_concept_id(self):
+        query = ServiceQuery()
+
+        query.concept_id("S1299783579-LPDAAC_ECS")
+        self.assertEqual(query.params["concept_id"], ["S1299783579-LPDAAC_ECS"])
+        
+        query.concept_id(["S1299783579-LPDAAC_ECS", "S1441380236-PODAAC"])
+        self.assertEqual(query.params["concept_id"], ["S1299783579-LPDAAC_ECS", "S1441380236-PODAAC"])
+    
+    def test_invalid_concept_id(self):
+        query = ServiceQuery()
+
+        with self.assertRaises(ValueError):
+            query.concept_id("G1327299284-LPDAAC_ECS")
+        
+        with self.assertRaises(ValueError):
+            query.concept_id(["C1299783579-LPDAAC_ECS", "G1327299284-LPDAAC_ECS"])
+

--- a/tests/test_tool.py
+++ b/tests/test_tool.py
@@ -1,0 +1,71 @@
+import unittest
+
+from cmr.queries import ToolQuery
+
+class TestToolClass(unittest.TestCase):
+
+    def test_name(self):
+        query = ToolQuery()
+        query.name("name")
+
+        self.assertIn("name", query.params)
+        self.assertEqual(query.params["name"], "name")
+    
+    def test_provider(self):
+        query = ToolQuery()
+        query.provider("provider")
+
+        self.assertIn("provider", query.params)
+        self.assertEqual(query.params["provider"], "provider")
+
+    def test_native_id(self):
+        query = ToolQuery()
+        query.native_id("native_id")
+
+        self.assertIn("native_id", query.params)
+        self.assertEqual(query.params["native_id"], ["native_id"])
+
+    def test_native_ids(self):
+        query = ToolQuery()
+        query.native_id(["native_id1", "native_id2"])
+
+        self.assertIn("native_id", query.params)
+        self.assertEqual(query.params["native_id"], ["native_id1", "native_id2"])
+
+    def test_valid_formats(self):
+        query = ToolQuery()
+        formats = [
+            "json", "xml", "echo10", "iso", "iso19115",
+            "csv", "atom", "kml", "native", "dif", "dif10",
+            "opendata", "umm_json", "umm_json_v1_1" "umm_json_v1_9"]
+
+        for _format in formats:
+            query.format(_format)
+            self.assertEqual(query._format, _format)
+    
+    def test_invalid_format(self):
+        query = ToolQuery()
+
+        with self.assertRaises(ValueError):
+            query.format("invalid")
+            query.format("jsonn")
+            query.format("iso19116")
+    
+    def test_valid_concept_id(self):
+        query = ToolQuery()
+
+        query.concept_id("T1299783579-LPDAAC_ECS")
+        self.assertEqual(query.params["concept_id"], ["T1299783579-LPDAAC_ECS"])
+        
+        query.concept_id(["T1299783579-LPDAAC_ECS", "T1441380236-PODAAC"])
+        self.assertEqual(query.params["concept_id"], ["T1299783579-LPDAAC_ECS", "T1441380236-PODAAC"])
+    
+    def test_invalid_concept_id(self):
+        query = ToolQuery()
+
+        with self.assertRaises(ValueError):
+            query.concept_id("G1327299284-LPDAAC_ECS")
+        
+        with self.assertRaises(ValueError):
+            query.concept_id(["C1299783579-LPDAAC_ECS", "G1327299284-LPDAAC_ECS"])
+


### PR DESCRIPTION
- Add in tools and service cmr query classes to query umm-t and umm-s.
- Change the base query class to be more generic and created a GranuleCollectionBaseQuery and ToolServiceBaseQuery classes.
- Add in more parameters to query by provider, native id, and name.
- Made concept id query more generic for each classes.
- Added test cases for new tools query and service query classes.